### PR TITLE
Fix formatting of query.$sort

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -40,15 +40,15 @@ export default (client, options = {}) => {
       case GET_LIST:
         const {page, perPage} = params.pagination || {}
         const {field, order} = params.sort || {}
-        const sortKey = `$sort[${field === 'id' ? idKey : field}]`
-        dbg('field=%o, sort-key=%o', field, sortKey)
-        let sortVal = order === 'DESC' ? -1 : 1
+        dbg('field=%o, order=%o', field, order)
         if (perPage && page) {
           query['$limit'] = perPage
           query['$skip'] = perPage * (page - 1)
         }
         if (order) {
-          query[sortKey] = JSON.stringify(sortVal)
+          query['$sort'] = {
+            [field === 'id' ? idKey : field]: order === 'DESC' ? -1 : 1
+          }
         }
         Object.assign(query, fetchUtils.flattenObject(params.filter));
         dbg('query=%o', query)

--- a/test/restClient.spec.js
+++ b/test/restClient.spec.js
@@ -127,7 +127,9 @@ describe('Rest Client', function () {
       const query = {
         $limit: 20,
         $skip: 20 * 9,
-        '$sort[id]': '-1',
+        $sort: {
+          id: -1
+        },
         name: 'john',
         _userId: '1'
       };
@@ -177,7 +179,9 @@ describe('Rest Client', function () {
       const query = {
         $limit: 20,
         $skip: 20 * 9,
-        '$sort[id]': '-1',
+        $sort: {
+          id: -1
+        },
         name: 'john',
         'address.city': 'London'
       };
@@ -222,7 +226,9 @@ describe('Rest Client', function () {
       const query = {
         $limit: 20,
         $skip: 20 * 9,
-        '$sort[_id]': '-1',
+        $sort: {
+          _id: -1
+        },
         name: 'john'
       };
       return asyncResult.then(result => {
@@ -266,7 +272,9 @@ describe('Rest Client', function () {
       const query = {
         $limit: 20,
         $skip: 20 * 9,
-        '$sort[_id]': '-1',
+        $sort: {
+          _id: -1
+        },
         name: 'john'
       };
       return asyncResult.then(result => {
@@ -294,7 +302,9 @@ describe('Rest Client', function () {
       const query = {
         $limit: 20,
         $skip: 20 * 9,
-        '$sort[id]': '-1',
+        $sort: {
+          id: -1
+        },
         name: 'john'
       };
       return asyncResult.then(result => {


### PR DESCRIPTION
Update tests to reflect needed change

Change format of the query object in GET_LIST

From:
```js
query: {
  '$sort[createdAt]': '-1'
}
```

To:
```js
query: {
  '$sort': {
    'createdAt': -1
  }
}
```

Fixes bug when using Feathers Websocket transport

Closes #84