### PR TITLE
Fix Nested Queries in GET_LIST

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -50,7 +50,7 @@ export default (client, options = {}) => {
             [field === 'id' ? idKey : field]: order === 'DESC' ? -1 : 1,
           };
         }
-        Object.assign(query, fetchUtils.flattenObject(params.filter));
+        Object.assign(query, params.filter);
         dbg('query=%o', query);
         return service.find({ query });
       case GET_ONE:

--- a/test/restClient.spec.js
+++ b/test/restClient.spec.js
@@ -186,7 +186,9 @@ describe('Rest Client', function () {
           id: -1,
         },
         name: 'john',
-        'address.city': 'London',
+        address: {
+          city: 'London',
+        }
       };
       return asyncResult.then(() => {
         expect(fakeService.find.calledWith({


### PR DESCRIPTION
For an unknown reason, query params were being flattened in GET_LIST.
This resulted in requests with nested query params failing.
This commit removes the flattening.

Fixes #90