### PR TITLE
Update Node version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:10.15.1
     working_directory: ~/ra-data-feathers
     steps:
       - checkout


### PR DESCRIPTION
CircleCI was configured to use Node v7, which is not LTS and was
end of life almost 2 years ago. Some deps were complaining about
this and causing CI to fail.

This commit updates CircleCI config to use Node 10.15.1, the
current LTS release. This will have maintainence until Oct 2020

Fixes #88 