### PR TITLE
Correct default authenticate field name

### DIFF
--- a/src/authClient.js
+++ b/src/authClient.js
@@ -18,7 +18,7 @@ export default (client, options = {}) => (type, params) => {
     redirectTo,
   } = Object.assign({}, {
     storageKey: 'token',
-    authenticate: { type: 'local' },
+    authenticate: { strategy: 'local' },
     permissionsKey: 'permissions',
     permissionsField: 'roles',
     passwordField: 'password',


### PR DESCRIPTION
Use `strategy` field name instead of `type` as required by FeatherJS https://docs.feathersjs.com/api/authentication/client.html#appauthenticateoptions