### PR TITLE
Issue #81 Performant bulk actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ const options = {
   },
 }
 ```
+`Performant Bulk Actions` can be used by enabling multi options in the feathers application
 
 ### Auth Provider (authClient)
 `authClient` also accepts two parameters. `client` and `options`.

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -72,6 +72,15 @@ export default (client, options = {}) => {
       case DELETE:
         return service.remove(params.id);
       case DELETE_MANY:
+        if (service.options.multi) {
+          return service.remove(null, {
+            query: {
+              [idKey]: {
+                $in: params.ids,
+              },
+            },
+          });
+        }
         return Promise.all(params.ids.map(id => (service.remove(id))));
       default:
         return Promise.reject(`Unsupported FeathersJS restClient action type ${type}`);

--- a/test/restClient.spec.js
+++ b/test/restClient.spec.js
@@ -35,7 +35,6 @@ let aorClient;
 let fakeClient;
 let fakeService;
 
-
 function setupClient(options = {}) {
   const { multi } = options || false;
   fakeService = {

--- a/test/restClient.spec.js
+++ b/test/restClient.spec.js
@@ -14,7 +14,7 @@ import {
 const { expect } = require('chai');
 const sinon = require('sinon');
 const debug = require('debug');
-const { restClient } = require('../lib');
+const { restClient } = require('../src');
 
 debug('ra-data-feathers:test');
 
@@ -28,13 +28,16 @@ const getResult = { id: 1, title: 'gotten' };
 const updateResult = { id: 1, title: 'updated' };
 const createResult = { id: 1, title: 'created' };
 const removeResult = { id: 1, title: 'deleted' };
+const removeManyResult = [{ id: 1 }, { id: 2 }];
 const authenticateResult = {};
 
 let aorClient;
 let fakeClient;
 let fakeService;
 
+
 function setupClient(options = {}) {
+  const { multi } = options || false;
   fakeService = {
     find: sinon.stub().returns(Promise.resolve(findResult)),
     get: sinon.stub().returns(Promise.resolve(getResult)),
@@ -45,7 +48,10 @@ function setupClient(options = {}) {
       Object.assign({}, data, { id }),
     )),
     create: sinon.stub().returns(Promise.resolve(createResult)),
-    remove: sinon.stub().returns(Promise.resolve(removeResult)),
+    remove: multi
+      ? sinon.stub().returns(Promise.resolve(removeManyResult))
+      : sinon.stub().returns(Promise.resolve(removeResult)),
+    options,
   };
 
   // sinon.spy(fakeService.find)
@@ -467,21 +473,26 @@ describe('Rest Client', function () {
   describe('when called with DELETE_MANY', function () {
     const params = { ids: [1, 2] };
     beforeEach(function () {
-      setupClient();
+      setupClient({ multi: true });
       asyncResult = aorClient(DELETE_MANY, 'posts', params);
     });
 
-    it("calls the client's remove method twice with the ids in params", function () {
+    it("calls the client's remove method once with the ids in params", function () {
       return asyncResult.then(() => {
-        expect(fakeService.remove.calledTwice).to.be.true;
-        expect(fakeService.remove.firstCall.calledWith(1));
-        expect(fakeService.remove.secondCall.calledWith(2));
+        expect(fakeService.remove.calledOnce).to.be.true;
+        expect(fakeService.remove.firstCall.calledWith({
+          query: {
+            id: {
+              $in: [1, 2],
+            },
+          },
+        }));
       });
     });
 
     it('returns the ids of the records returned by the client', function () {
       return asyncResult.then((result) => {
-        expect(result).to.deep.equal({ data: [removeResult.id, removeResult.id] });
+        expect(result).to.deep.equal({ data: removeManyResult.map(record => record.id) });
       });
     });
   });


### PR DESCRIPTION
# Description

Currently, DELETE_MANY make multiple calls to the Feathers client, one for each ID to be updated/deleted. This is based on ra-data-simple-rest, which handles bulk actions like this because there isn't a 'standard' REST way to handle multi-item changes. Feathers doesn't have this limitation.

other bulk actions other then DELETE_MANY will need to be updated in the future. 

Fixes #81 

## Type of change

- New feature 
- This change requires a documentation update

# How Has This Been Tested?

Updated tests in restClient.spec.js to assert the response is as expected. 
