### PR TITLE
Undo softDelete option and support v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ The ra-data-feathers data provider (restClient) accepts two arguments: `client` 
 const options = {
   id: 'id', // If your database uses an id field other than 'id'. Optional.
   usePatch: false, // Use PATCH instead of PUT for UPDATE requests. Optional.
-	softDelete: false, // for use with Feathers-Plus softDelete2, setting this option to true passes `$ignoreDeletedAt: true` to your feathers client in PATCH, UPDATE or UPDATE_MANY requests. https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#softdelete2
   my_resource: { // Options for individual resources can be set by adding an object with the same name. Optional.
     id: 'id', // If this specific table uses an id field other than 'id'. Optional.
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,70 +211,6 @@
         }
       }
     },
-    "@feathers-plus/batch-loader": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@feathers-plus/batch-loader/-/batch-loader-0.3.6.tgz",
-      "integrity": "sha512-r+n31iZ/B5Rl1mLkC9/S20UI445MdkZvE3VBmjupep2t8OuyTYHPkFEgR25HY6khH+RothK1VL3B5eumk9N2QQ=="
-    },
-    "@feathersjs/commons": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.4.tgz",
-      "integrity": "sha512-ZPpzyZA3CPfoa9AuFv3BJUI/ubzaaXixp8T/pqeMFPT6DOaU/6oF7lz1RxwimzfJNna4gy/HByt0EoLSI3BKWg=="
-    },
-    "@feathersjs/errors": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.3.6.tgz",
-      "integrity": "sha512-VCohY/AQU13xYyZGl6rfdUgE+2bjaI76a4aEb6reIphHKgb4mnjYlg2PzS1/hcU1qUNi515kY9yQa5HsE7J1dQ==",
-      "requires": {
-        "debug": "^4.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@feathersjs/feathers": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.3.1.tgz",
-      "integrity": "sha512-Mb7Maz03TIIksomXeInmXNb5ykxgsAyBCuJDQHK+oIDrDRR9m+ZbUrslCkMk/s0nr6cW5DmVbWz9s11SCXFW5A==",
-      "requires": {
-        "@feathersjs/commons": "^4.0.0",
-        "debug": "^4.0.0",
-        "events": "^3.0.0",
-        "uberproto": "^2.0.2"
-      },
-      "dependencies": {
-        "@feathersjs/commons": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.0.0.tgz",
-          "integrity": "sha512-hyCLse4RiNt7WLPQ0KSudjoVnwiRykhYzIZdtDon9i2usPaoYkFw/fEYZrkE5HVB+sUTwphZoZ1oOntRk1MShg=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "@material-ui/core": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.3.1.tgz",
@@ -342,14 +278,6 @@
       "dev": true,
       "requires": {
         "recompose": "^0.26.0 || ^0.27.0"
-      }
-    },
-    "@types/graphql": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
-      "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
-      "requires": {
-        "graphql": "*"
       }
     },
     "@types/jss": {
@@ -1583,11 +1511,6 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2172,11 +2095,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
-    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -2238,7 +2156,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2266,52 +2185,6 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
-        }
-      }
-    },
-    "feathers-hooks-common": {
-      "version": "4.20.7",
-      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-4.20.7.tgz",
-      "integrity": "sha512-+9CXrj2FeDAOlDmU7MBdmYg72F+na17kss/97Vyus4zRbLJvuV2ky6Jto16NSJ906OsbYjHHXKIKzw1uPnlx3w==",
-      "requires": {
-        "@feathers-plus/batch-loader": "^0.3.0",
-        "@feathersjs/commons": "^1.4.0",
-        "@feathersjs/errors": "^3.3.0",
-        "@feathersjs/feathers": "^3.1.3",
-        "@types/graphql": "^14.0.4",
-        "ajv": "^5.5.2",
-        "debug": "^3.1.0",
-        "graphql": "^14.0.2",
-        "libphonenumber-js": "^1.6.8",
-        "process": "0.11.10",
-        "traverse": "^0.6.6"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
       }
     },
@@ -2518,7 +2391,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2539,12 +2413,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2559,17 +2435,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2686,7 +2565,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2698,6 +2578,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2712,6 +2593,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2719,12 +2601,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2743,6 +2627,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2823,7 +2708,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2835,6 +2721,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2920,7 +2807,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2956,6 +2844,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2975,6 +2864,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3018,12 +2908,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3069,6 +2961,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -3094,14 +2987,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
-    },
-    "graphql": {
-      "version": "14.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.1.tgz",
-      "integrity": "sha512-j1dEuS7q14QKdhv5xDaePDmJ54odK/cCZWdG8vT07KOEPoEEh8oj/SWzaboI/9zfwplbdE6UQv4aePnzJv7o6A==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
     },
     "growl": {
       "version": "1.10.5",
@@ -3375,7 +3260,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -3417,7 +3303,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3445,6 +3332,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -3691,11 +3579,6 @@
         "handlebars": "^4.0.3"
       }
     },
-    "iterall": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3859,6 +3742,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3871,22 +3755,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "libphonenumber-js": {
-      "version": "1.7.22",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.22.tgz",
-      "integrity": "sha512-KCK4874gp640B+d1zjNi2ZiZ3ubEUPH/0B9AwcuhHDVAL6NdthxC8obbdhGlo7FcEpjFVwEMDoHRfi+lI8NM/g==",
-      "requires": {
-        "minimist": "^1.2.0",
-        "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "load-json-file": {
@@ -4155,6 +4023,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -4964,13 +4833,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -5056,7 +4927,8 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -5069,11 +4941,6 @@
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scroll": {
       "version": "2.0.3",
@@ -5416,11 +5283,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -5453,11 +5315,6 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
-    },
-    "uberproto": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.4.tgz",
-      "integrity": "sha512-c/5xjTcztW9XVhrkCycHQRBIAxww5JpDKk/q0zc2tVdQn6ZQvnChWgLvQaWAT1Al5JvRyvloUI15ad41m6dYwg=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -5577,20 +5434,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,12 +43,11 @@
   "homepage": "https://github.com/josx/ra-data-feathers#readme",
   "peerDependencies": {
     "react-admin": "^2.1.1",
-    "@feathersjs/client": "^3.5.3"
+    "@feathersjs/client": "^3.5.3 || ^4.3.0"
   },
   "dependencies": {
     "chai-as-promised": "^7.1.1",
     "debug": "^3.0.0",
-    "feathers-hooks-common": "^4.20.7",
     "jwt-decode": "^2.2.0",
     "object-diff": "^0.0.4"
   },

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -14,8 +14,6 @@ import diff from 'object-diff';
 
 const dbg = debug('ra-data-feathers:rest-client');
 
-const { paramsForServer } = require('feathers-hooks-common');
-
 const defaultIdKey = 'id'
 
 function getIdKey({ resource, options }) {
@@ -30,13 +28,6 @@ function deleteProp(obj, prop) {
 
 export default (client, options = {}) => {
   const usePatch = !!options.usePatch;
-  const softDelete = !!options.softDelete;
-  const serverParams = function () {
-    if (softDelete) {
-      return paramsForServer({ $ignoreDeletedAt: true });
-    }
-    return null;
-  };
   const mapRequest = (type, resource, params) => {
     const idKey = getIdKey({ resource, options });
     dbg('type=%o, resource=%o, params=%o, idKey=%o', type, resource, params, idKey);
@@ -74,18 +65,18 @@ export default (client, options = {}) => {
       case UPDATE:
         if (usePatch) {
           const data = params.previousData ? diff(params.previousData, params.data) : params.data;
-          return service.patch(params.id, data, serverParams());
+          return service.patch(params.id, data);
         } else {
           const data = (idKey !== defaultIdKey) ? deleteProp(params.data, defaultIdKey) : params.data
-          return service.update(params.id, data, serverParams());
+          return service.update(params.id, data);
         }
       case UPDATE_MANY:
         if (usePatch) {
           const data = params.previousData ? diff(params.previousData, params.data) : params.data;
-          return Promise.all(params.ids.map(id => (service.patch(id, data, serverParams()))));
+          return Promise.all(params.ids.map(id => (service.patch(id, data))));
         } else {
           const data = (idKey !== defaultIdKey) ? deleteProp(params.data, defaultIdKey) : params.data
-          return Promise.all(params.ids.map(id => (service.update(id, data, serverParams()))));
+          return Promise.all(params.ids.map(id => (service.update(id, data))));
         }
       case CREATE:
         return service.create(params.data);


### PR DESCRIPTION
Support `@feathersjs/client` of version 4 (fix issues #123 and #124).

Undo `softDelete` functionality introduced in #121 for issue #120. For two reasons:

1) `feathers-hooks-common` does not support v4 yet and it is unknown when it will be.

2) Functionality to modify `params`/`data`/`id` (which was asked in #120) is already present without additional options and code in this package - `hooks`. Just use `client.hooks(...)` or `client.service(path).hooks(...)` for custom logic.