### PR TITLE
add $ignoreDeletedAt: true for GET_MANY, GET_LIST, GET_ONE

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The ra-data-feathers data provider (restClient) accepts two arguments: `client` 
 const options = {
   id: 'id', // If your database uses an id field other than 'id'. Optional.
   usePatch: false, // Use PATCH instead of PUT for UPDATE requests. Optional.
-	softDelete: false, // for use with Feathers-Plus softDelete2, setting this option to true passes `$ignoreDeletedAt: true` to your feathers client in PATCH, UPDATE or UPDATE_MANY requests. https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#softdelete2
+	softDelete: false, // for use with Feathers-Plus softDelete2, setting this option to true passes `$ignoreDeletedAt: true` to your feathers client in GET_MANY, GET_LIST, GET_ONE, PATCH, UPDATE AND UPDATE_MANY requests. https://feathers-plus.github.io/v1/feathers-hooks-common/index.html#softdelete2
   my_resource: { // Options for individual resources can be set by adding an object with the same name. Optional.
     id: 'id', // If this specific table uses an id field other than 'id'. Optional.
   },


### PR DESCRIPTION
Hi, 
I am hoping you'd be willing to consider another pull request concerning softDelete2, I realized the previous pull request, while it works great for patching logically deleted items, is incomplete. It does not account for the case when `softDelete()` has been added to the `get` and `find` methods of a service, which is the standard implementation for softDelete2. Without the change in this PR, those who have added softDelete to `get` and `find` will not be able to retrieve 'Archived' (i.e. logically deleted) items, which breaks the ability to 'Archive' and 'Unarchive' items within react-admin. 

I apologize for the the oversight, on our project, I am responsible for the react-admin integration, while another team member is responsible for the api. When the team decided that adding softDelete to `get` and `find` methods would better suit the needs of one of our front end apps, I was cued into the fact that using softDelete in this way is actually the standard implementation. I believe this fix will appeal to a broader user base, since it works as expected for both our previous setup (softDelete not active for get and find) and the standard way where softDelete is active for all requests. Thank you for your consideration!