### PR TITLE
fix(feathers-4): call reAuthenticate in AUTH_CHECK if available

### DIFF
--- a/test/authClient.spec.js
+++ b/test/authClient.spec.js
@@ -70,6 +70,28 @@ describe('Auth Client', function () {
         return expect(authClient('AUTH_CHECK', {})).to.be.fulfilled;
       });
     });
+
+    describe('when client.reAuthenticate() is available', function () {
+      before(function () {
+        global.localStorage = {
+          getItem: sinon.stub().returns('somedata'),
+        };
+      });
+      after(function () {
+        delete global.localStorage;
+      });
+
+      it('should call client.reAuthenticate if is a function', function () {
+        const customClient = {
+          reAuthenticate: sinon.stub().returns(new Promise(() => {})),
+        };
+
+        const customAuthClient = aorAuthClient(customClient, options);
+
+        customAuthClient('AUTH_CHECK', {});
+        return expect(customClient.reAuthenticate.called);
+      });
+    });
   });
 
   describe('when called with an invalid type', function () {


### PR DESCRIPTION
This fixes an issue where, on `@feathersjs/authentication-client` version `4.3.10`, the `authenticated` check does not happen on reload. Calling `reAuthenticate` before resolving the `AUTH_CHECK` case promise fixes this.