### PR TITLE
Add support for custom query operators in GET_MANY 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,17 @@ The ra-data-feathers data provider (restClient) accepts two arguments: `client` 
 `client`should be a [configured Feathers client instance](#Feathers-Client). This argument is required.
 
 `options` contains configurable options for the ra-data-feathers restClient. The `options` argument is optional and can be omitted. In this case, defaults will be used.
-```
+```js
 const options = {
   id: 'id', // If your database uses an id field other than 'id'. Optional.
   usePatch: false, // Use PATCH instead of PUT for UPDATE requests. Optional.
   my_resource: { // Options for individual resources can be set by adding an object with the same name. Optional.
     id: 'id', // If this specific table uses an id field other than 'id'. Optional.
   },
+  /* Allows to use custom query operators from various feathers-database-adapters in GET_MANY calls.
+   * Will be merged with the default query operators ['$gt', '$gte', '$lt', '$lte', '$ne', '$sort', '$or', '$nin', '$in']
+   */
+  customQueryOperators: []
 }
 ```
 `Performant Bulk Actions` can be used by enabling multi options in the feathers application
@@ -70,7 +74,7 @@ const options = {
 
 `options` contains configurable options for the ra-data-feathers authClient. The `options` argument is optional and can be omitted. In this case, defaults shown below will be used.
 
-```
+```js
 const options = {
   storageKey: 'token', // The key in localStorage used to store the authentication token
   authenticate: { // Options included in calls to Feathers client.authenticate
@@ -88,7 +92,7 @@ const options = {
 ### Usage with the react-admin `<Admin>` component
 
 ra-data-feathers can be used by passing the `restClient` and `authClient` to the react-admin `<Admin>` component as the `dataProvider` and `authProvider` params respectively:
-```
+```jsx
 <Admin
   dataProvider={restClient(feathersClient, restClientConfig)}
   authProvider={authClient(feathersClient, authClientConfig)}

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -64,6 +64,8 @@ export default (client, options = {}) => {
       case GET_LIST:
         const { page, perPage } = params.pagination || {};
         const { field, order } = params.sort || {};
+        const additionalQueryOperators = Array.isArray(options.customQueryOperators) ? options.customQueryOperators : [];
+        const allUniqueQueryOperators = [...new Set(queryOperators.concat(additionalQueryOperators))]
         dbg('field=%o, order=%o', field, order);
         if (perPage && page) {
           query.$limit = perPage;
@@ -74,7 +76,7 @@ export default (client, options = {}) => {
             [field === defaultIdKey ? idKey : field]: order === 'DESC' ? -1 : 1,
           };
         }
-        Object.assign(query, flatten(params.filter, '', queryOperators));
+        Object.assign(query, flatten(params.filter, '', allUniqueQueryOperators));
         dbg('query=%o', query);
         return service.find({ query });
       case GET_ONE:

--- a/test/restClient.spec.js
+++ b/test/restClient.spec.js
@@ -269,6 +269,48 @@ describe('Rest Client', function () {
     });
   });
 
+  describe('customQueryOperators-option: when called with GET_LIST', function () {
+    const params = {
+      pagination: {
+        page: 10,
+        perPage: 20,
+      },
+      sort: {
+        field: 'id',
+        order: 'DESC',
+      },
+      filter: {
+        name: { $regexp: 'john' },
+      },
+    };
+
+    it("customQueryOperators-option: calls the client's find method", function () {
+      setupClient({ customQueryOperators: ['$regexp'] });
+      asyncResult = aorClient(GET_LIST, 'posts', params);
+      return asyncResult.then(() => {
+        expect(fakeService.find.calledOnce).to.be.true;
+      });
+    });
+
+    it('customQueryOperators-option: returns the data returned by the client', function () {
+      return asyncResult.then((result) => {
+        expect(result).to.deep.equal(findResult);
+      });
+    });
+
+    it('customQueryOperators-option: correctly formats custom query operators in the query passed to the client', function () {
+      const query = {
+        $limit: 20,
+        $skip: 180,
+        $sort: { id: -1 },
+        name: { $regexp: 'john' },
+      };
+      return asyncResult.then(() => {
+        expect(fakeService.find.calledWith({ query })).to.be.true;
+      });
+    });
+  });
+
   describe('resource-id-option: when called with GET_LIST', function () {
     const params = {
       pagination: {


### PR DESCRIPTION
- Add `customQueryOperators` field to `restClient.options`
- Custom query operators will be merged with hardcoded default query oprators