### PR TITLE
[RFR] fix auth client logout action issue

### DIFF
--- a/src/authClient.js
+++ b/src/authClient.js
@@ -36,8 +36,7 @@ export default (client, options = {}) => (type, params) => {
         [passwordField]: password,
       });
     case AUTH_LOGOUT:
-      localStorage.removeItem(permissionsKey);
-      return client.logout();
+      return client.logout().then(() => localStorage.removeItem(permissionsKey));
     case AUTH_CHECK:
       const hasJwtInStorage = !!localStorage.getItem(storageKey);
       const hasReAuthenticate = Object.getOwnPropertyNames(client).includes('reAuthenticate')


### PR DESCRIPTION
If we remove the permissions first, then we might have an "unauthorized" response from the server on the DELETE.

Delete permissions first then client.logout():
```
curl 'http://localhost:3030/authentication' \
  -X 'DELETE' \
  -H 'Connection: keep-alive' \
  -H 'Accept: application/json' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36' \
  -H 'Origin: http://localhost:3000' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Referer: http://localhost:3000/' \
  -H 'Accept-Language: es,en-US;q=0.9,en;q=0.8' \
  --compressed
```

client.logout() first then delete permissions:
```
curl 'http://localhost:3030/authentication' \
  -X 'DELETE' \
  -H 'Connection: keep-alive' \
  -H 'Accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6ImFjY2VzcyJ9.eyJwZXJtaXNzaW9ucyI6ImFkbWluIiwiaWF0IjoxNTk0MzEwMzczLCJleHAiOjE1OTQzOTY3NzMsImF1ZCI6Imh0dHBzOi8veW91cmRvbWFpbi5jb20iLCJpc3MiOiJmZWF0aGVycyIsInN1YiI6IjEiLCJqdGkiOiJjYzQ3NGFjZS0zOWFjLTRmMmQtOWM4Zi04MTk0Y2U3NWFlNzUifQ.-y2h2G1RHI5p4_WwALneBVz-kostWj_NG9CWR0PJ5eo' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36' \
  -H 'Origin: http://localhost:3000' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Referer: http://localhost:3000/' \
  -H 'Accept-Language: es,en-US;q=0.9,en;q=0.8' \
  --compressed
```