### PR TITLE
Fixes default storageKey value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const options = {
 
 ```js
 const options = {
-  storageKey: 'token', // The key in localStorage used to store the authentication token
+  storageKey: 'feathers-jwt', // The key in localStorage used to store the authentication token
   authenticate: { // Options included in calls to Feathers client.authenticate
     strategy: 'local', // The authentication strategy Feathers should use
   },

--- a/src/authClient.js
+++ b/src/authClient.js
@@ -21,7 +21,7 @@ export default (client, options = {}) => (type, params) => {
     redirectTo,
     logoutOnForbidden,
   } = Object.assign({}, {
-    storageKey: 'token',
+    storageKey: 'feathers-jwt',
     authenticate: { strategy: 'local' },
     permissionsKey: 'permissions',
     permissionsField: 'roles',

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -45,7 +45,7 @@ const configInvalid = {
 expectError(restClient(null, configInvalid));
 
 const allAuthOptions = {
-  storageKey: 'token', // The key in localStorage used to store the authentication token
+  storageKey: 'feathers-jwt', // The key in localStorage used to store the authentication token
   authenticate: { // Options included in calls to Feathers client.authenticate
     strategy: 'local', // The authentication strategy Feathers should use
   },
@@ -60,7 +60,7 @@ const allAuthOptions = {
 expectType<IAuthClientResult>(authClient(null, allAuthOptions));
 
 const someOptions = {
-  storageKey: 'token', // The key in localStorage used to store the authentication token
+  storageKey: 'feathers-jwt', // The key in localStorage used to store the authentication token
   authenticate: { // Options included in calls to Feathers client.authenticate
     strategy: 'local', // The authentication strategy Feathers should use
   },


### PR DESCRIPTION
I was just trying to run the code but it didn't work. After debugging, I discovered that the `@feathersjs/authentication-client` setup script that I copy/paste from official docs is using a different field name.

`auth` is used in the docs of @feathersjs/authentication-client, in the library itself default is `feathers-jwt`, and here is `token`. it's a complete mess :(

Since new users often run the code by copying examples from the documentation, in order not to create unnecessary obstacles and problems for other new users, I think it will be useful to add this fix. 

I also made PR to docs https://github.com/feathersjs/docs/pull/1539