### PR TITLE
Support legacy reac admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/josx/ra-data-feathers#readme",
   "peerDependencies": {
     "@feathersjs/client": "^3.5.3 || ^4.3.0",
-    "react-admin": "^4.7.2"
+    "react-admin": "^2.1.1|| ^3.0.0|| ^4.0.0"
   },
   "dependencies": {
     "debug": "^3.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,8 @@
     "isolatedModules": true,
     "emitDeclarationOnly": true,
     "outDir": "lib",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
 }


### PR DESCRIPTION
close #184 

- Peerdependencies can be react-admin v2, v3 or v4.
- Avoid type checking in declaration 
